### PR TITLE
feat(licensify): add option scanBrowser

### DIFF
--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -74,6 +74,16 @@ function extractContributors (pkg, summary) {
     }
 }
 
+function extract (pkg) {
+    var summary = {};
+    extractLicense(pkg, summary);
+    extractLicenses(pkg, summary);
+    extractAuthor(pkg, summary);
+    extractMaintainers(pkg, summary);
+    extractContributors(pkg, summary);
+    return summary;
+}
+
 function createLicenseHeader (licenses) {
     var header = '';
     header += '/**\n';
@@ -100,16 +110,6 @@ module.exports = function licensify (b, opts) {
     var checkedPkg = [];
 
     b.on('package', function (pkg) {
-        var extract = function(pkg) {
-            var summary = {};
-            extractLicense(pkg, summary);
-            extractLicenses(pkg, summary);
-            extractAuthor(pkg, summary);
-            extractMaintainers(pkg, summary);
-            extractContributors(pkg, summary);
-            return summary;
-        };
-
         if (!opts.scanBrowser) {
             licenses[pkg.name] = extract(pkg);
             return;

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -1,7 +1,7 @@
 /**
  * licensify:
  *   Browserify plugin to prepend license header to bundle
- * 
+ *
  * https://github.com/twada/licensify
  *
  * Copyright (c) 2014-2015 Takuto Wada
@@ -97,15 +97,55 @@ function createLicenseHeader (licenses) {
 
 module.exports = function licensify (b, opts) {
     var licenses = {};
+    var checkedPkg = [];
 
     b.on('package', function (pkg) {
-        var summary = {};
-        extractLicense(pkg, summary);
-        extractLicenses(pkg, summary);
-        extractAuthor(pkg, summary);
-        extractMaintainers(pkg, summary);
-        extractContributors(pkg, summary);
-        licenses[pkg.name] = summary;
+        var extract = function(pkg) {
+            var summary = {};
+            extractLicense(pkg, summary);
+            extractLicenses(pkg, summary);
+            extractAuthor(pkg, summary);
+            extractMaintainers(pkg, summary);
+            extractContributors(pkg, summary);
+            return summary;
+        };
+
+        if (!opts.scanBrowser) {
+            licenses[pkg.name] = extract(pkg);
+            return;
+        }
+        if (!pkg.browser) {
+            licenses[pkg.name] = extract(pkg);
+            return;
+        }
+        if (typeName(pkg.browser) === 'string') {
+            licenses[pkg.name] = extract(pkg);
+            return;
+        }
+
+        // If this pkg has "browser" field, licensify scans the field and extracts informations.
+        // see https://github.com/substack/browserify-handbook#browser-field
+        var skipScan = false;
+        checkedPkg.map(function (checked) {
+            skipScan = (pkg.name === checked);
+        });
+
+        if (skipScan) {
+            licenses[pkg.name] = extract(pkg);
+            return;
+        }
+
+        checkedPkg.push(pkg.name);
+        Object.keys(pkg.browser).map(function (key) {
+            var subPkgPath = pkg.__dirname + '/node_modules/' + key + '/package.json';
+            try {
+                var subPkg = require(subPkgPath);
+            } catch (e) {
+                return;
+            }
+            licenses[subPkg.name] = extract(subPkg);
+        });
+        licenses[pkg.name] = extract(pkg);
     });
 
     b.on('bundle', function (pipeline) {

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -107,7 +107,7 @@ function createLicenseHeader (licenses) {
 
 module.exports = function licensify (b, opts) {
     var licenses = {};
-    var checkedPkg = [];
+    var scannedPkg = [];
 
     b.on('package', function (pkg) {
         if (!opts.scanBrowser) {
@@ -125,17 +125,15 @@ module.exports = function licensify (b, opts) {
 
         // If this pkg has "browser" field, licensify scans the field and extracts informations.
         // see https://github.com/substack/browserify-handbook#browser-field
-        var skipScan = false;
-        checkedPkg.map(function (checked) {
-            skipScan = (pkg.name === checked);
+        var alreadyScanned = scannedPkg.some(function (scanned) {
+            return pkg.name === scanned;
         });
-
-        if (skipScan) {
+        if (alreadyScanned) {
             licenses[pkg.name] = extract(pkg);
             return;
         }
 
-        checkedPkg.push(pkg.name);
+        scannedPkg.push(pkg.name);
         Object.keys(pkg.browser).map(function (key) {
             var subPkgPath = pkg.__dirname + '/node_modules/' + key + '/package.json';
             try {

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -134,7 +134,7 @@ module.exports = function licensify (b, opts) {
         }
 
         scannedPkg.push(pkg.name);
-        Object.keys(pkg.browser).map(function (key) {
+        Object.keys(pkg.browser).forEach(function (key) {
             var subPkgPath = pkg.__dirname + '/node_modules/' + key + '/package.json';
             try {
                 var subPkg = require(subPkgPath);

--- a/test/test-scan-browser-fields/index.js
+++ b/test/test-scan-browser-fields/index.js
@@ -1,0 +1,2 @@
+var angular = require('angular');
+var jquery = require('jquery');

--- a/test/test-scan-browser-fields/node_modules/angular/dummy.js
+++ b/test/test-scan-browser-fields/node_modules/angular/dummy.js
@@ -1,0 +1,1 @@
+module.exports = 'dummy';

--- a/test/test-scan-browser-fields/node_modules/angular/package.json
+++ b/test/test-scan-browser-fields/node_modules/angular/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "angular",
+  "description": "This is a dummy package for the test.",
+  "version": "0.0.1",
+  "author": {
+    "name": "Okuno Kentaro",
+    "email": "okunokentaro@me.com",
+    "url": "http://github.com/armorik83"
+  },
+  "license": {
+    "type": "MIT"
+  }
+}

--- a/test/test-scan-browser-fields/node_modules/jquery/dummy.js
+++ b/test/test-scan-browser-fields/node_modules/jquery/dummy.js
@@ -1,0 +1,1 @@
+module.exports = 'dummy';

--- a/test/test-scan-browser-fields/node_modules/jquery/package.json
+++ b/test/test-scan-browser-fields/node_modules/jquery/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jquery",
+  "description": "This is a dummy package for the test.",
+  "version": "0.0.1",
+  "author": {
+    "name": "Okuno Kentaro",
+    "email": "okunokentaro@me.com",
+    "url": "http://github.com/armorik83"
+  },
+  "license": {
+    "type": "MIT"
+  }
+}

--- a/test/test-scan-browser-fields/package.json
+++ b/test/test-scan-browser-fields/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "licensify-test-scan-browser-fields",
+  "description": "",
+  "version": "0.0.1",
+  "author": {
+    "name": "Okuno Kentaro",
+    "email": "okunokentaro@me.com",
+    "url": "http://github.com/armorik83"
+  },
+  "browser": {
+    "jquery": "./node_modules/jquery/dummy.js",
+    "angular": "./node_modules/angular/dummy.js"
+  },
+  "license": {
+    "type": "MIT"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -62,3 +62,50 @@ describe('licensify', function () {
     });
 
 });
+
+describe('licensify scan browser fields', function () {
+    describe('true scanBrowser', function () {
+        var expectedModules = [
+            'licensify-test-scan-browser-fields',
+            'jquery',
+            'angular'
+        ];
+        expectedModules.forEach(function (moduleName) {
+            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+            it('ensure header includes [' + moduleName + ']', function (done) {
+                var save = saveFirstChunk();
+                var b = browserify();
+                b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
+                b.plugin(licensify, {scanBrowser: true}); // with option
+                b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+                    assert(!err);
+                    var actual = save.firstChunk;
+                    assert(re.test(actual));
+                    done();
+                }));
+            });
+        });
+    });
+
+    describe('false scanBrowser as a default', function () {
+        var expectedNotIncludedModules = [
+            'jquery',
+            'angular'
+        ];
+        expectedNotIncludedModules.forEach(function (moduleName) {
+            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+            it('ensure header NOT includes [' + moduleName + ']', function (done) {
+                var save = saveFirstChunk();
+                var b = browserify();
+                b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
+                b.plugin(licensify); // default
+                b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+                    assert(!err);
+                    var actual = save.firstChunk;
+                    assert(!re.test(actual));
+                    done();
+                }));
+            });
+        });
+    });
+});


### PR DESCRIPTION
If our package.json has field of `"browser"` like an alias, currently licensify cannot scan to license specified in `"browser"`.
I'm going to suggest. I thought of added a new option `"scanBrowser"`.
This is not a breaking change.

# How to use
```js
var browserify = require('browserify');
var licensify = require('licensify');

var b = browserify();
b.add('/path/to/your/file');
b.plugin(licensify, {scanBrowser: true}); // assign an option, the default is false
b.bundle().pipe(somewhere)
```

Thanks for an amazing library!