### PR TITLE
always scan browser field

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,25 +168,9 @@ b.plugin(licensify);
 b.bundle().pipe(dest)
 ```
 
+### browser field
 
-#### scanBrowser option
-
-if `scanBrowser` option is truthy, licensify scans and traverses [`browser` field](https://github.com/substack/browserify-handbook#browser-field) too.
-
-by command-line
-
-```
-$ browserify main.js -p [ licensify --scanBrowser ] > build/bundle.js 
-```
-
-or programmatically
-
-```javascript
-var b = browserify();
-b.add('/path/to/your/file');
-b.plugin(licensify, {scanBrowser: true});
-b.bundle().pipe(dest)
-```
+Since 2.0.0, licensify scans and traverses [`browser` field](https://github.com/substack/browserify-handbook#browser-field) if exists.
 
 
 INSTALL

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -146,7 +146,7 @@ module.exports = function licensify (b, opts) {
             return;
         }
 
-        if (!opts.scanBrowser || !pkg.browser || typeName(pkg.browser) === 'string') {
+        if (!pkg.browser || typeName(pkg.browser) === 'string') {
             if (!mainPkg) {
                 mainPkg = extract(pkg);
             } else {

--- a/test/test.js
+++ b/test/test.js
@@ -100,69 +100,62 @@ describe('licensify', function () {
 });
 
 
-describe('`scanBrowser` option to scan `browser` fields in package.json:', function () {
+describe('scan `browser` field in package.json by default', function () {
+    var header;
 
-    describe('when truthy', function () {
-        var header;
-
-        before(function (done) {
-            var save = saveFirstChunk();
-            var b = browserify();
-            b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
-            b.plugin(licensify, {scanBrowser: true}); // with option
-            b.bundle().pipe(save).pipe(es.wait(function(err, data) {
-                assert(!err);
-                header = save.firstChunk;
-                done();
-            }));
-        });
-
-        var expectedModules = [
-            'licensify-test-scan-browser-fields',
-            'jquery',
-            'angular'
-        ];
-        expectedModules.forEach(function (moduleName) {
-            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
-            it('ensure header includes [' + moduleName + ']', function () {
-                assert(re.test(header));
-            });
-        });
+    before(function (done) {
+        var save = saveFirstChunk();
+        var b = browserify();
+        b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
+        b.plugin(licensify);
+        b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+            assert(!err);
+            header = save.firstChunk;
+            done();
+        }));
     });
 
-    describe('default is false', function () {
-        var header;
-
-        before(function (done) {
-            var save = saveFirstChunk();
-            var b = browserify();
-            b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
-            b.plugin(licensify); // default
-            b.bundle().pipe(save).pipe(es.wait(function(err, data) {
-                assert(!err);
-                header = save.firstChunk;
-                done();
-            }));
+    var expectedModules = [
+        'licensify-test-scan-browser-fields',
+        'jquery',
+        'angular'
+    ];
+    expectedModules.forEach(function (moduleName) {
+        var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+        it('ensure header includes [' + moduleName + ']', function () {
+            assert(re.test(header));
         });
+    });
+});
 
-        var expectedModules = [
-            'licensify-test-scan-browser-fields'
-        ];
-        expectedModules.forEach(function (moduleName) {
-            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
-            it('ensure header includes [' + moduleName + ']', function () {
-                assert(re.test(header));
+
+describe('`scanBrowser` option is just ignored since 2.0.0', function () {
+    [true, false].forEach(function (flag) {
+        describe('when ' + flag, function () {
+            var header;
+
+            before(function (done) {
+                var save = saveFirstChunk();
+                var b = browserify();
+                b.add(path.normalize(path.join(__dirname, 'test-scan-browser-fields', 'index.js')));
+                b.plugin(licensify, {scanBrowser: flag});
+                b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+                    assert(!err);
+                    header = save.firstChunk;
+                    done();
+                }));
             });
-        });
 
-        var notToBeIncludedModules = [
-            'jquery',
-            'angular'
-        ];
-        notToBeIncludedModules.forEach(function (moduleName) {
-            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
-            it('ensure header does NOT include [' + moduleName + ']', function () {
-                assert(!re.test(header));
+            var expectedModules = [
+                'licensify-test-scan-browser-fields',
+                'jquery',
+                'angular'
+            ];
+            expectedModules.forEach(function (moduleName) {
+                var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+                it('ensure header includes [' + moduleName + ']', function () {
+                    assert(re.test(header));
+                });
             });
         });
     });


### PR DESCRIPTION
#### BREAKING CHANGE: 

`scanBrowser` option is ignored since this release and treated as `scanBrowser=true` at all times.

fixes #5

To be released as 2.0.0
