### PR TITLE
SourceMap support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,5 @@ node_js:
   - "0.12"
   - "4.2"
   - "stable"
-before_install:
-  - "npm install -g browserify"
 script:
-  - "npm test"
-  - "npm uninstall -g browserify"
-  - "npm install browserify"
   - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
-sudo: false
 node_js:
-  - '0.10'
-  - '0.12'
-  - '4.2'
-  - 'stable'
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "stable"
+before_install:
+  - "npm install -g browserify"
+script:
+  - "npm test"
+  - "npm uninstall -g browserify"
+  - "npm install browserify"
+  - "npm test"

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -12,11 +12,9 @@
 
 var typeName = require('type-name');
 var through = require('through2');
-var fs = require('fs');
-var path = require('path');
-var extend = require('xtend');
-var requireg = require('requireg');
-var resolve = require('resolve');
+var convert = require('convert-source-map');
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var props = [
     'license',
     'licenses',
@@ -135,6 +133,12 @@ function createLicenseHeader (mainPkg, licenses) {
     return header;
 }
 
+function newlinesIn (src) {
+    if (!src) return 0;
+    var newlines = src.match(/\n/g);
+    return newlines ? newlines.length : 0;
+}
+
 module.exports = function licensify (b, opts) {
     var licenses = {};
     var scannedPkg = [];
@@ -176,41 +180,40 @@ module.exports = function licensify (b, opts) {
 
     b.on('bundle', function () {
         var first = true;
+        var header;
+        b.pipeline.get('wrap').push(through.obj(function (buf, enc, next) {
+            if (first) {
+                header = createLicenseHeader(mainPkg, licenses);
+                this.push(new Buffer(header));
+                first = false;
+            }
+            this.push(buf);
+            next();
+        }));
         if (b._options.debug) {
-            b.pipeline.get('debug').unshift(through.obj(function (row, enc, next) {
-                if (first) {
-                    var browserifyIndexPath = requireg.resolve('browserify');
-                    var browserifyPath = path.dirname(browserifyIndexPath);
-                    var browserPackIndexPath = resolve.sync('browser-pack', { basedir: browserifyPath });
-                    var browserPackPath = path.dirname(browserPackIndexPath);
-                    var originalPrelude;
-                    if (b._options.prelude) {
-                        originalPrelude = b._options.prelude;
-                    } else {
-                        var defaultPreludePath = path.join(browserPackPath, '_prelude.js');
-                        originalPrelude = fs.readFileSync(defaultPreludePath, 'utf8');
-                    }
-                    var newPrelude = createLicenseHeader(mainPkg, licenses) + originalPrelude;
-                    var originalBpackStream = b._bpack;
-                    var createBpack = require(browserPackPath);
-                    var newBpackStream = createBpack(extend(b._options, { prelude: newPrelude, raw: true }));
-                    newBpackStream.standaloneModule = originalBpackStream.standaloneModule;
-                    newBpackStream.hasExports = originalBpackStream.hasExports;
-                    b.pipeline.get('pack').splice(b.pipeline.get('pack').indexOf(originalBpackStream), 1, newBpackStream);
-                    b._bpack = newBpackStream;
-                    b._options.prelude = newPrelude;
-                    first = false;
-                }
-                this.push(row);
-                next();
-            }));
-        } else {
             b.pipeline.get('wrap').push(through.obj(function (buf, enc, next) {
-                if (first) {
-                    this.push(new Buffer(createLicenseHeader(mainPkg, licenses)));
-                    first = false;
+                var conv = convert.fromSource(buf.toString('utf8'));
+                if (conv) {
+                    var map = conv.toObject();
+                    var consumer = new SourceMapConsumer(map);
+                    var generator = new SourceMapGenerator({
+                        file: map.file,
+                        sourceRoot: map.sourceRoot
+                    });
+                    var offset = newlinesIn(header);
+                    consumer.eachMapping(function (m) {
+                        generator.addMapping({
+                            source: m.source,
+                            name: m.name,
+                            original: { line: m.originalLine, column: m.originalColumn },
+                            generated: { line: offset + m.generatedLine, column: m.generatedColumn }
+                        });
+                    });
+                    var outMap = convert.fromJSON(generator.toString());
+                    this.push(new Buffer(outMap.toComment()));
+                } else {
+                    this.push(buf);
                 }
-                this.push(buf);
                 next();
             }));
         }

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -196,7 +196,7 @@ module.exports = function licensify (b, opts) {
                 var conv = convert.fromSource(buf.toString('utf8'));
                 if (conv) {
                     var offsetMap = offsetLines(conv.toObject(), newlinesIn(header));
-                    this.push(new Buffer(convert.fromObject(offsetMap).toComment()));
+                    this.push(new Buffer('\n' + convert.fromObject(offsetMap).toComment() + '\n'));
                 } else {
                     this.push(buf);
                 }

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -12,6 +12,11 @@
 
 var typeName = require('type-name');
 var through = require('through2');
+var fs = require('fs');
+var path = require('path');
+var extend = require('xtend');
+var requireg = require('requireg');
+var resolve = require('resolve');
 var props = [
     'license',
     'licenses',
@@ -171,13 +176,43 @@ module.exports = function licensify (b, opts) {
 
     b.on('bundle', function () {
         var first = true;
-        b.pipeline.get('wrap').push(through.obj(function (buf, enc, next) {
-            if (first) {
-                this.push(new Buffer(createLicenseHeader(mainPkg, licenses)));
-                first = false;
-            }
-            this.push(buf);
-            next();
-        }));
+        if (b._options.debug) {
+            b.pipeline.get('debug').unshift(through.obj(function (row, enc, next) {
+                if (first) {
+                    var browserifyIndexPath = requireg.resolve('browserify');
+                    var browserifyPath = path.dirname(browserifyIndexPath);
+                    var browserPackIndexPath = resolve.sync('browser-pack', { basedir: browserifyPath });
+                    var browserPackPath = path.dirname(browserPackIndexPath);
+                    var originalPrelude;
+                    if (b._options.prelude) {
+                        originalPrelude = b._options.prelude;
+                    } else {
+                        var defaultPreludePath = path.join(browserPackPath, '_prelude.js');
+                        originalPrelude = fs.readFileSync(defaultPreludePath, 'utf8');
+                    }
+                    var newPrelude = createLicenseHeader(mainPkg, licenses) + originalPrelude;
+                    var originalBpackStream = b._bpack;
+                    var createBpack = require(browserPackPath);
+                    var newBpackStream = createBpack(extend(b._options, { prelude: newPrelude, raw: true }));
+                    newBpackStream.standaloneModule = originalBpackStream.standaloneModule;
+                    newBpackStream.hasExports = originalBpackStream.hasExports;
+                    b.pipeline.get('pack').splice(b.pipeline.get('pack').indexOf(originalBpackStream), 1, newBpackStream);
+                    b._bpack = newBpackStream;
+                    b._options.prelude = newPrelude;
+                    first = false;
+                }
+                this.push(row);
+                next();
+            }));
+        } else {
+            b.pipeline.get('wrap').push(through.obj(function (buf, enc, next) {
+                if (first) {
+                    this.push(new Buffer(createLicenseHeader(mainPkg, licenses)));
+                    first = false;
+                }
+                this.push(buf);
+                next();
+            }));
+        }
     });
 };

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -15,6 +15,7 @@ var through = require('through2');
 var convert = require('convert-source-map');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
+var offsetLines = require('offset-sourcemap-lines');
 var props = [
     'license',
     'licenses',
@@ -194,23 +195,8 @@ module.exports = function licensify (b, opts) {
             b.pipeline.get('wrap').push(through.obj(function (buf, enc, next) {
                 var conv = convert.fromSource(buf.toString('utf8'));
                 if (conv) {
-                    var map = conv.toObject();
-                    var consumer = new SourceMapConsumer(map);
-                    var generator = new SourceMapGenerator({
-                        file: map.file,
-                        sourceRoot: map.sourceRoot
-                    });
-                    var offset = newlinesIn(header);
-                    consumer.eachMapping(function (m) {
-                        generator.addMapping({
-                            source: m.source,
-                            name: m.name,
-                            original: { line: m.originalLine, column: m.originalColumn },
-                            generated: { line: offset + m.generatedLine, column: m.generatedColumn }
-                        });
-                    });
-                    var outMap = convert.fromJSON(generator.toString());
-                    this.push(new Buffer(outMap.toComment()));
+                    var offsetMap = offsetLines(conv.toObject(), newlinesIn(header));
+                    this.push(new Buffer(convert.fromObject(offsetMap).toComment()));
                 } else {
                     this.push(buf);
                 }

--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -13,8 +13,6 @@
 var typeName = require('type-name');
 var through = require('through2');
 var convert = require('convert-source-map');
-var SourceMapConsumer = require('source-map').SourceMapConsumer;
-var SourceMapGenerator = require('source-map').SourceMapGenerator;
 var offsetLines = require('offset-sourcemap-lines');
 var props = [
     'license',

--- a/package.json
+++ b/package.json
@@ -23,16 +23,21 @@
     }
   ],
   "dependencies": {
+    "requireg": "^0.1.5",
+    "resolve": "^1.1.6",
     "through2": "^2.0.0",
-    "type-name": "^2.0.0"
+    "type-name": "^2.0.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "browserify": "^11.0.1",
+    "convert-source-map": "^1.1.3",
     "espower-loader": "^1.0.0",
     "event-stream": "^3.3.1",
     "intelli-espower-loader": "^1.0.0",
     "mocha": "^2.3.0",
-    "power-assert": "^1.0.0"
+    "power-assert": "^1.0.0",
+    "source-map": "^0.5.3"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "convert-source-map": "^1.1.3",
+    "offset-sourcemap-lines": "^0.1.0",
     "source-map": "^0.5.3",
     "through2": "^2.0.0",
     "type-name": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "browserify": "^11.0.1",
     "convert-source-map": "^1.1.3",
     "espower-loader": "^1.0.0",
     "event-stream": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "event-stream": "^3.3.1",
     "intelli-espower-loader": "^1.0.0",
     "mocha": "^2.3.0",
-    "power-assert": "^1.0.0"
+    "power-assert": "^1.0.0",
+    "source-map": "^0.5.3"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "convert-source-map": "^1.1.3",
     "offset-sourcemap-lines": "^0.1.0",
-    "source-map": "^0.5.3",
     "through2": "^2.0.0",
     "type-name": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,20 +23,17 @@
     }
   ],
   "dependencies": {
-    "requireg": "^0.1.5",
-    "resolve": "^1.1.6",
+    "convert-source-map": "^1.1.3",
+    "source-map": "^0.5.3",
     "through2": "^2.0.0",
-    "type-name": "^2.0.0",
-    "xtend": "^4.0.1"
+    "type-name": "^2.0.0"
   },
   "devDependencies": {
-    "convert-source-map": "^1.1.3",
-    "espower-loader": "^1.0.0",
+    "browserify": "^13.0.0",
     "event-stream": "^3.3.1",
     "intelli-espower-loader": "^1.0.0",
     "mocha": "^2.3.0",
-    "power-assert": "^1.0.0",
-    "source-map": "^0.5.3"
+    "power-assert": "^1.0.0"
   },
   "directories": {
     "test": "test"

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,7 @@
 delete require.cache[require.resolve('../')];
 var licensify = require('../');
 var path = require('path');
-var requireg = require('requireg');
-var browserify = requireg('browserify');
+var browserify = require('browserify');
 var through = require('through2');
 var es = require('event-stream');
 var convert = require('convert-source-map');
@@ -70,7 +69,7 @@ describe('licensify', function () {
     ];
     var expectedUrls = [
         'homepage: https://github.com/twada/licensify',
-        'homepage: https://github.com/beatgammit/base64-js',
+        'homepage: https://github.com/beatgammit/base64-js#readme',
         'homepage: https://github.com/feross/buffer',
         'homepage: https://github.com/isaacs/core-util-is#readme',
         'homepage: https://github.com/Gozala/events#readme',
@@ -103,8 +102,6 @@ describe('licensify', function () {
                         var map = convert.fromSource(code, true).toObject();
                         var consumer = new SourceMapConsumer(map);
                         var pos = consumer.generatedPositionFor({ source: 'index.js', line: 1, column: 0 });
-                        var re = /\}\)\(\{$/gm;
-                        assert(re.test(header), 'prelude does not end with newline');
                         assert(pos.line === (positionWithoutLicensify.line + newlinesIn(header)));
                     }
                     done();


### PR DESCRIPTION
support browserify's `--debug` or `-d` option that appends SourceMap at the end of bundle.

- [x] rough implementation
- [x] travis integration
- [x] extract `offset-sourcemap-lines` module
- [x] `debug` option
- [x] `prelude` option
- [x] field test

