### PR TITLE
[WIP] Bugfix: `licences` field without `type` field

### DIFF
--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -44,11 +44,14 @@ function extractLicenses (pkg, summary) {
     if (typeName(pkg.licenses) === 'Array') {
         summary.licenses = pkg.licenses.map(function (license) {
             return appendUrlToLicense(license.type);
-        }).join(', ');
+        }).filter(function (v) { return !!v; }).join(', ');
     }
 }
 
 function appendUrlToLicense (name) {
+    if (!name) {
+        return name;
+    }
     var url = nameToUrl(name);
     if (url) {
         return name + ' (' + url + ')';

--- a/test/test-typeless-package/index.js
+++ b/test/test-typeless-package/index.js
@@ -1,0 +1,3 @@
+module.exports = function (name) {
+    return 'Hello, ' + name;
+};

--- a/test/test-typeless-package/package.json
+++ b/test/test-typeless-package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-typeless-package",
+  "description": "",
+  "version": "0.0.1",
+  "licenses": [
+    {
+      "license": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -313,3 +313,31 @@ describe('private packages', function () {
         });
     });
 });
+
+
+describe('type-less licenses', function () {
+    var expectedModules = [
+        'test-typeless-package'
+    ];
+
+    describe('should also be in output', function () {
+        var header;
+        before(function (done) {
+            var save = saveFirstChunk();
+            var b = browserify();
+            b.add(path.normalize(path.join(__dirname, 'test-typeless-package', 'index.js')));
+            b.plugin(licensify);
+            b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+                assert(!err);
+                header = save.firstChunk;
+                done();
+            }));
+        });
+        expectedModules.forEach(function (moduleName) {
+            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+            it('ensure header includes [' + moduleName + ']', function () {
+                assert(re.test(header));
+            });
+        });
+    });
+});


### PR DESCRIPTION
Licensify explodes when package has `licenses` field but doesn't have corresponding `type` field.

- [x] add repro case
- [x] fix it
