### PR TITLE
Support two operators and/or as multiple common licenses

### DIFF
--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -24,9 +24,13 @@ var props = [
     'homepage',
     'version'
 ];
+var operators = [
+  'OR',
+  'AND'
+]
 
 function extractLicense (pkg, summary) {
-    var name;
+    var name = '', operator = '', names = [], licenses = [];
     switch (typeName(pkg.license)) {
     case 'string':
         name = pkg.license;
@@ -35,8 +39,21 @@ function extractLicense (pkg, summary) {
         name = pkg.license.type;
         break;
     }
-    if (name) {
-        summary.license = appendUrlToLicense(name);
+
+    if (name.match(/^\(.+\)$/)) {
+        names = name.match(/\(([^)]+)\)/)[1]
+        operators.forEach(function (o) {
+            var license = names.split(o);
+            if (license.length > licenses.length) {
+              operator = o;
+              licenses = license;
+            }
+        });
+        summary.license = licenses.map(function (license) {
+            return appendUrlToLicense(license.trim());
+        }).filter(function (v) { return !!v; }).join(' ' + operator + ' ');
+    } else if (name) {
+      summary.license = appendUrlToLicense(name);
     }
 }
 

--- a/test/test-multiple-common-licenses/index.js
+++ b/test/test-multiple-common-licenses/index.js
@@ -1,0 +1,2 @@
+var and = require('test-conjunctive-and-operator');
+var or = require('test-disjunctive-or-operator');

--- a/test/test-multiple-common-licenses/node_modules/test-conjunctive-and-operator/index.js
+++ b/test/test-multiple-common-licenses/node_modules/test-conjunctive-and-operator/index.js
@@ -1,0 +1,1 @@
+module.exports = 'and';

--- a/test/test-multiple-common-licenses/node_modules/test-conjunctive-and-operator/package.json
+++ b/test/test-multiple-common-licenses/node_modules/test-conjunctive-and-operator/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-conjunctive-and-operator",
+  "description": "",
+  "version": "0.0.1",
+  "license" : "(LGPL-2.1 AND MIT)"
+}

--- a/test/test-multiple-common-licenses/node_modules/test-disjunctive-or-operator/index.js
+++ b/test/test-multiple-common-licenses/node_modules/test-disjunctive-or-operator/index.js
@@ -1,0 +1,1 @@
+module.exports = 'or';

--- a/test/test-multiple-common-licenses/node_modules/test-disjunctive-or-operator/package.json
+++ b/test/test-multiple-common-licenses/node_modules/test-disjunctive-or-operator/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-disjunctive-or-operator",
+  "description": "",
+  "version": "0.0.1",
+  "license" : "(LGPL-2.1 OR MIT)"
+}

--- a/test/test-multiple-common-licenses/package.json
+++ b/test/test-multiple-common-licenses/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-multiple-common-licenses",
+  "description": "",
+  "version": "0.0.1",
+  "dependencies": {
+    "test-conjunctive-and-operator": "./node_modules/test-conjunctive-and-operator",
+    "test-disjunctive-or-operator": "./node_modules/test-disjunctive-or-operator"
+  },
+  "license": "MIT"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -341,3 +341,40 @@ describe('type-less licenses', function () {
         });
     });
 });
+
+describe('multiple common licenses', function () {
+    var expectedModules = [
+        'test-conjunctive-and-operator',
+        'test-disjunctive-or-operator'
+    ];
+    var expectedOperators = [
+        'OR', 'AND'
+    ]
+
+    describe('should also be in output', function () {
+        var header;
+        before(function (done) {
+            var save = saveFirstChunk();
+            var b = browserify();
+            b.add(path.normalize(path.join(__dirname, 'test-multiple-common-licenses', 'index.js')));
+            b.plugin(licensify);
+            b.bundle().pipe(save).pipe(es.wait(function(err, data) {
+                assert(!err);
+                header = save.firstChunk;
+                done();
+            }));
+        });
+        expectedModules.forEach(function (moduleName) {
+            var re = new RegExp(' \* ' + moduleName + '\:$', 'gm');
+            it('ensure header includes [' + moduleName + ']', function () {
+                assert(re.test(header));
+            });
+        });
+        expectedOperators.forEach(function (operators) {
+            var re = new RegExp(operators, 'gm');
+            it('ensure header includes [' + operators + ']', function () {
+                assert(re.test(header));
+            });
+        });
+    });
+});


### PR DESCRIPTION
Supported `AND` and `OR` operators.
https://www.npmjs.com/package/spdx#composite-license-expressions

Related issues: https://github.com/twada/licensify/issues/15