### PR TITLE
Avoid trailing spaces on lines containing only an asterisk

### DIFF
--- a/lib/licensify.js
+++ b/lib/licensify.js
@@ -155,7 +155,7 @@ function createEachHeader(pkg, pluginOptions) {
             header += ' *   ' + prop + ': ' + pkg[prop] + '\n';
         }
     });
-    header += ' * \n';
+    header += ' *\n';
     return header;
 }
 
@@ -164,7 +164,7 @@ function createLicenseHeader (mainPkg, licenses, pluginOptions) {
     header += '/**\n';
     header += ' * Modules in this bundle\n';
     header += ' * @license\n';
-    header += ' * \n';
+    header += ' *\n';
     header += createEachHeader(mainPkg, pluginOptions);
     var keys = Object.keys(licenses);
     keys.sort();


### PR DESCRIPTION
Spotted this because my editor was highlighting the trailing spaces.

Unrelated: thank you for this library. Since bundling amounts to distributing other people's code, it is far too easy to completely erase their copyright notices, especially after using a minifier. It's nice to have licensify so I don't start claiming other people's work!